### PR TITLE
remove async loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ const glTFToModel = require('./glTFToModel');
 const modelToXKT = require('./modelToXKT');
 
 module.exports = {
-  glTFToXKT(gltfData) {
+  glTFToXKT(gltfData, options) {
     const gltf = JSON.parse(gltfData);
-    const model = glTFToModel(gltf);
+    const model = glTFToModel(gltf, options);
     const arrayBuffer = modelToXKT(model);
     return new Buffer.from(arrayBuffer);
   }


### PR DESCRIPTION
The async file loading is not very useful: 
* files are loaded from the same disk, the parallel load isn't really faster
* most time is used by heavy computation and async gives no help there
* the code becomes more complex
* it may lead to errors (the index.js wasn't updated to async)